### PR TITLE
fix error in getImages that allows all users to see all images of all…

### DIFF
--- a/src/main/kotlin/de/cetvericov/photodump/images/persistence/repository/ImageMetadataRepository.kt
+++ b/src/main/kotlin/de/cetvericov/photodump/images/persistence/repository/ImageMetadataRepository.kt
@@ -2,5 +2,8 @@ package de.cetvericov.photodump.images.persistence.repository
 
 import de.cetvericov.photodump.images.persistence.entity.ImageMetadataEntity
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
 
-interface ImageMetadataRepository: ReactiveCrudRepository<ImageMetadataEntity, Long>
+interface ImageMetadataRepository: ReactiveCrudRepository<ImageMetadataEntity, Long> {
+    fun findByOwnerId(ownerId: Long): Flux<ImageMetadataEntity>
+}


### PR DESCRIPTION
… users, not only their own ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image retrieval now requires user authentication and returns only images owned by the authenticated user.
  * Users will receive a 404 error if their account cannot be found when accessing images.

* **Bug Fixes**
  * Prevented unauthorized access to images by restricting image retrieval to authenticated users only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->